### PR TITLE
Port config and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ iex -S mix
 
 Test the client in your browser: [http://localhost:8085](http://localhost:8085)
 
+####  Changing the port (optional)
+
+The default port can be changed in `config/config.exs`.
+
 ### Testing
 
 You can run the test suite by:

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,5 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env()}.exs"
+
+config :elixir_snake, cowboy_port: 8085

--- a/lib/elixir_snake/application.ex
+++ b/lib/elixir_snake/application.ex
@@ -9,7 +9,7 @@ defmodule ElixirSnake.Application do
     # List all child processes to be supervised
     children = [
       # Starts a worker by calling: ElixirSnake.Worker.start_link(arg)
-      Plug.Adapters.Cowboy2.child_spec(scheme: :http, plug: ElixirSnake.Router, options: [port: 8085])
+      Plug.Adapters.Cowboy2.child_spec(scheme: :http, plug: ElixirSnake.Router, options: [port: Application.get_env(:elixir_snake, :cowboy_port)])
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/elixir_snake/elixir_snake_router.ex
+++ b/lib/elixir_snake/elixir_snake_router.ex
@@ -10,7 +10,14 @@ defmodule ElixirSnake.Router do
 
   # Routes!
   get "/" do
-    send_resp(conn, 200, "This is the home of a battlesnake built with Elixir, please visit battlesnake.io to learn more")
+    conn
+    |> put_resp_content_type("text/html")
+    |> send_resp(200,
+       """
+       <div>
+        This is the home of a battlesnake built with Elixir, please visit <a href='https://www.battlesnake.io/'>battlesnake.io</a> to learn more.
+       </div>
+       """)
   end
 
   post "/start" do


### PR DESCRIPTION
# Summary

* Moved the cowboy port config into `config/config.exs`, which I think is more convention. I also added a note in the README.md of where to set the port. This is in reference to [this comment](https://github.com/battlesnakeio/starter-snake-elixir/pull/1#issuecomment-430088912).

* On the main endpoint of the app, we were previously returning raw text. I set the content type to html and returned a clickable link to the battlesnake homepage. It now looks like:

<img width="614" alt="screenshot 2018-10-19 23 59 06" src="https://user-images.githubusercontent.com/3220620/47258850-5ac5f980-d456-11e8-8d29-1a1134162c7c.png">

