### PR TITLE
Remove Taunts

### DIFF
--- a/lib/elixir_snake.ex
+++ b/lib/elixir_snake.ex
@@ -4,14 +4,14 @@ defmodule ElixirSnake do
   """
 
   @doc """
-    This is the response to Post /start 
+    This is the response to Post /start
     This is where you define your color
   """
-  def start_resp(start_request) do 
+  def start_resp(start_request) do
     IO.inspect(start_request)
+
     %{
-      color: "#c0ffee",
-      taunt: "I'm READY"
+      color: "#c0ffee"
     }
   end
 
@@ -22,9 +22,9 @@ defmodule ElixirSnake do
   def move_resp(board) do
     IO.inspect(board)
     move = "right"
+
     %{
-      move: move,
-      taunt: "Go Time"
+      move: move
     }
   end
 

--- a/lib/elixir_snake/application.ex
+++ b/lib/elixir_snake/application.ex
@@ -9,7 +9,11 @@ defmodule ElixirSnake.Application do
     # List all child processes to be supervised
     children = [
       # Starts a worker by calling: ElixirSnake.Worker.start_link(arg)
-      Plug.Adapters.Cowboy2.child_spec(scheme: :http, plug: ElixirSnake.Router, options: [port: Application.get_env(:elixir_snake, :cowboy_port)])
+      Plug.Adapters.Cowboy2.child_spec(
+        scheme: :http,
+        plug: ElixirSnake.Router,
+        options: [port: Application.get_env(:elixir_snake, :cowboy_port)]
+      )
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/elixir_snake/elixir_snake_router.ex
+++ b/lib/elixir_snake/elixir_snake_router.ex
@@ -12,12 +12,14 @@ defmodule ElixirSnake.Router do
   get "/" do
     conn
     |> put_resp_content_type("text/html")
-    |> send_resp(200,
-       """
-       <div>
-        This is the home of a battlesnake built with Elixir, please visit <a href='https://www.battlesnake.io/'>battlesnake.io</a> to learn more.
-       </div>
-       """)
+    |> send_resp(
+      200,
+      """
+      <div>
+       This is the home of a battlesnake built with Elixir, please visit <a href='https://www.battlesnake.io/'>battlesnake.io</a> to learn more.
+      </div>
+      """
+    )
   end
 
   post "/start" do

--- a/test/elixir_snake_test.exs
+++ b/test/elixir_snake_test.exs
@@ -21,5 +21,4 @@ defmodule ElixirSnakeTest do
     move_resp = ElixirSnake.move_resp("")
     assert Map.has_key?(move_resp, :move)
   end
-
 end


### PR DESCRIPTION
Small cleanup of the starter snake, primarily removing the taunts which are not included in the 2019 tournament and running the Elixir built in formatter for readability. 

Closes battlesnakeio/roadmap#261